### PR TITLE
perf: remove unnecessary date adding

### DIFF
--- a/report.py
+++ b/report.py
@@ -1,14 +1,11 @@
 import hashlib
 import logging
-import datetime
-import pytz
 import cv2
 import easyocr
 import requests_html
 
 from log import config_logging
 import os
-os.environ['TZ'] = 'Asia/Shanghai'
 
 def main():
     username = os.environ.get("username")
@@ -114,7 +111,6 @@ def main():
     '''
     add_form['__EVENTTARGET'] = 'dcbc'  # 修改为databc
     #add_form['__EVENTTARGET'] = 'databc'
-    add_form['tbrq'] = datetime.datetime.now(pytz.timezone('PRC')).strftime('%Y-%#m-%#d')
 
     '''
     # 打卡

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 easyocr==1.4.1
 opencv_python_headless==4.5.4.60
 requests_html==0.10.0
-pytz==2022.1


### PR DESCRIPTION
The `tbrq` field's value is generated by server, it's not necessary to add this value by `datetime`.

![image](https://user-images.githubusercontent.com/15844309/164232525-d2bf6dc3-737d-479a-bbfd-46956d7d1d18.png)
